### PR TITLE
Fixes for the 2017 repo copy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 #--------------------------------------------------------------------------------
 # Values for this workshop - EDIT THIS SECTION.
 #--------------------------------------------------------------------------------
-workshop_repo   : "https://github.com/Duke-GCB/SciComp-Oct-2016"
-workshop_site   : "http://duke-gcb.github.io/SciComp-Oct-2016/"
+workshop_repo   : "https://github.com/Duke-GCB/SciComp-Nov-2017"
+workshop_site   : "http://duke-gcb.github.io/SciComp-Nov-2017/"
 #--------------------------------------------------------------------------------
 # Standard Software Carpentry settings - should not need to be modified.
 #--------------------------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -147,34 +147,34 @@ self. The course includes introductions to
 
 <div class="row">
   <div class="col-md-6">
-    <h3>Day 1</h3>
+    <h3>Day 1, 1-4.30pm</h3>
     <table class="table table-striped">
       <tr> <td>13:00</td>  <td>Automating tasks with the Unix shell</td> </tr>
-      <tr> <td>15:00</td>  <td>Break</td> </tr>
+      <tr> <td>14:45</td>  <td>Break</td> </tr>
       <tr> <td>16:30</td>  <td>Wrap-up</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
-    <h3>Day 2</h3>
+    <h3>Day 2, 1-4.30pm</h3>
     <table class="table table-striped">
       <tr> <td>13:00</td>  <td>Building programs with Python</td> </tr>
-      <tr> <td>15:00</td>  <td>Break</td> </tr>
+      <tr> <td>14:45</td>  <td>Break</td> </tr>
       <tr> <td>16:30</td>  <td>Wrap-up</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
-    <h3>Day 3</h3>
+    <h3>Day 3, 1-4.30pm</h3>
     <table class="table table-striped">
       <tr> <td>13:00</td>  <td>Version control with Git</td> </tr>
-      <tr> <td>15:00</td>  <td>Break</td> </tr>
+      <tr> <td>14:45</td>  <td>Break</td> </tr>
       <tr> <td>16:30</td>  <td>Wrap-up</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
-    <h3>Day 4</h3>
+    <h3>Day 4, 1-4.30pm</h3>
     <table class="table table-striped">
       <tr> <td>13:00</td>  <td>Running programs on an HPC cluster</td> </tr>
-      <tr> <td>15:00</td>  <td>Break</td> </tr>
+      <tr> <td>14:45</td>  <td>Break</td> </tr>
       <tr> <td>16:30</td>  <td>Wrap-up</td> </tr>
     </table>
   </div>
@@ -285,33 +285,39 @@ self. The course includes introductions to
 <div class="row">
   <div class="col-md-3">
     <h3>Bash shell</h3>
-    <ul>
 <!--
+    <ul>
       <li><a href="https://github.com/Duke-GCB/SciComp-Materials/archive/materials-v0.2.zip">Download</a></li>
- -->
     </ul>
+ -->
   </div>
   <div class="col-md-3">
     <h3>Programming w/ Python</h3>
+<!--
     <ul>
       <li><a href="https://github.com/dleehr/scicomp-python/releases/download/v2/python-fasta.zip">Download python-fasta.zip</a></li>
     </ul>
+ -->
   </div>
   <div class="col-md-3">
     <h3>Git version control</h3>
+<!--
     <ul>
       <li><a href="https://github.com/Duke-GCB/SciComp-Materials/archive/git-lesson-v0.3.zip">Download git-lesson-v0.3.zip</a></li>
       <li><a href="http://swcarpentry.github.io/git-novice/">Software Carpentry lesson</a></li>
     </ul>
+ -->
   </div>
   <div class="col-md-3">
     <h3>Running programs on an HPC cluster</h3>
+<!--
     <ul>
       <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/oct-2016/docs/HPC-Slides.pdf">Slides</a></li>
       <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/oct-2016/docs/HPC-Cheat-Sheet-DCC.pdf">DCC Cheat Sheet</a></li>
       <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/oct-2016/docs/HPC-Cheat-Sheet-HARDAC.pdf">HARDAC Cheat Sheet</a></li>
       <li><a href="https://slurm.schedmd.com/pdfs/summary.pdf">Slurm Commands</a></li>
     </ul>
+ -->
   </div>
 </div>
 


### PR DESCRIPTION
* Config file fixes so that Github links go to the 2017 repo
* Breaks scheduled at 2.45pm
* Turn off all materials downloads until closer to start of course