### PR TITLE
Update HPC materials links

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@ self. The course includes introductions to
     <h3>Programming w/ Python</h3>
 <!--
     <ul>
-      <li><a href="https://github.com/dleehr/scicomp-python/releases/download/v2/python-fasta.zip">Download python-fasta.zip</a></li>
+      <li><a href="https://github.com/Duke-GCB/SciComp-Nov-2017/releases/download/1.0/python-fasta.zip">Download python-fasta.zip</a></li>
     </ul>
  -->
   </div>
@@ -312,10 +312,14 @@ self. The course includes introductions to
     <h3>Running programs on an HPC cluster</h3>
 <!--
     <ul>
-      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/nov-2017/docs/HPC-Slides.pdf">Slides</a></li>
-      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/nov-2017/docs/HPC-Cheat-Sheet-DCC.pdf">DCC Cheat Sheet</a></li>
-      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/nov-2017/docs/HPC-Cheat-Sheet-HARDAC.pdf">HARDAC Cheat Sheet</a></li>
+      <li><a href="https://github.com/Duke-GCB/SciComp-Nov-2017/releases/download/1.0/HPC-Slides.pdf">Slides</a></li>
+
+      <li><a href="https://github.com/Duke-GCB/SciComp-Nov-2017/releases/download/1.0/HPC-Cheat-Sheet-DCC.pdf">DCC Cheat Sheet</a></li>
+
+      <li><a href="https://github.com/Duke-GCB/SciComp-Nov-2017/releases/download/1.0/HPC-Cheat-Sheet-HARDAC.pdf">HARDAC Cheat Sheet</a></li>
+
       <li><a href="https://slurm.schedmd.com/pdfs/summary.pdf">Slurm Commands</a></li>
+
       <li><a href="https://rc.duke.edu/wp-content/uploads/DCC_Workshop_10-06-2017.pdf">DCC Workshop Slides</a></li>
     </ul>
  -->

--- a/index.html
+++ b/index.html
@@ -312,10 +312,11 @@ self. The course includes introductions to
     <h3>Running programs on an HPC cluster</h3>
 <!--
     <ul>
-      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/oct-2016/docs/HPC-Slides.pdf">Slides</a></li>
-      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/oct-2016/docs/HPC-Cheat-Sheet-DCC.pdf">DCC Cheat Sheet</a></li>
-      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/oct-2016/docs/HPC-Cheat-Sheet-HARDAC.pdf">HARDAC Cheat Sheet</a></li>
+      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/nov-2017/docs/HPC-Slides.pdf">Slides</a></li>
+      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/nov-2017/docs/HPC-Cheat-Sheet-DCC.pdf">DCC Cheat Sheet</a></li>
+      <li><a href="https://github.com/johnbradley/scicomp-hpc/raw/nov-2017/docs/HPC-Cheat-Sheet-HARDAC.pdf">HARDAC Cheat Sheet</a></li>
       <li><a href="https://slurm.schedmd.com/pdfs/summary.pdf">Slurm Commands</a></li>
+      <li><a href="https://rc.duke.edu/wp-content/uploads/DCC_Workshop_10-06-2017.pdf">DCC Workshop Slides</a></li>
     </ul>
  -->
   </div>


### PR DESCRIPTION
The links are still commented out.
The files they reference may/will change as I finish updating the slides.